### PR TITLE
EntityZone: Add padding option

### DIFF
--- a/EntityZone.lua
+++ b/EntityZone.lua
@@ -54,9 +54,14 @@ function EntityZone:new(entity, options)
 
   local min, max = GetModelDimensions(GetEntityModel(entity))
   local dimensions = {min, max}
+  
+  local padding = 0.0
+  if options.padding ~= nil then
+    padding = options.padding + 0.0
+  end
 
-  local length = max.y - min.y
-  local width = max.x - min.x
+  local length = (max.y - min.y) + padding
+  local width = (max.x - min.x) + padding
   local pos = GetEntityCoords(entity)
 
   local zone = BoxZone:new(pos, length, width, options)


### PR DESCRIPTION
added entity padding option to extend length and width. tested with dumpsters and moving cars. negative padding values also work.

![image](https://user-images.githubusercontent.com/31749679/120433558-b69ee000-c3be-11eb-88f8-238f9e06ae12.png)
