### PR TITLE
Make isInside false by default

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -533,7 +533,7 @@ function PolyZone:onPointInOut(getPointCb, onPointInOutCb, waitInMS)
   if waitInMS ~= nil then _waitInMS = waitInMS end
 
   Citizen.CreateThread(function()
-    local isInside = nil
+    local isInside = false
     while not self.destroyed do
       if not self.paused then
         local point = getPointCb()


### PR DESCRIPTION
Make isInside false by default to prevent leave event triggering on zone creating