### PR TITLE
tweak: redundancy checks for control input

### DIFF
--- a/BoxZone.lua
+++ b/BoxZone.lua
@@ -66,7 +66,7 @@ local function _initDebug(zone, options)
   if not options.debugPoly then
     return
   end
-  
+
   Citizen.CreateThread(function()
     while not zone.destroyed do
       zone:draw()
@@ -127,7 +127,7 @@ end
 function BoxZone:isPointInside(point)
   if self.destroyed then
     print("[PolyZone] Warning: Called isPointInside on destroyed zone {name=" .. self.name .. "}")
-    return false 
+    return false
   end
 
   local startPos = self.startPos

--- a/CircleZone.lua
+++ b/CircleZone.lua
@@ -21,7 +21,7 @@ local function _initDebug(zone, options)
   if not options.debugPoly then
     return
   end
-  
+
   Citizen.CreateThread(function()
     while not zone.destroyed do
       zone:draw()

--- a/ComboZone.lua
+++ b/ComboZone.lua
@@ -106,7 +106,7 @@ local function _initDebug(zone, options)
   if not options.debugPoly then
     return
   end
-  
+
   Citizen.CreateThread(function()
     while not zone.destroyed do
       zone:draw()
@@ -157,7 +157,7 @@ function ComboZone:getZones(point)
   if not self.useGrid then
     return self.zones
   end
-  
+
   local grid = self.grid
   local x, y = _getGridCell(point)
   local row = grid[y]

--- a/EntityZone.lua
+++ b/EntityZone.lua
@@ -37,7 +37,7 @@ local function _initDebug(zone, options)
   if not options.debugPoly and not options.debugBlip then
     return
   end
-  
+
   Citizen.CreateThread(function()
     local entity = zone.entity
     local shouldDraw = options.debugPoly

--- a/client.lua
+++ b/client.lua
@@ -113,7 +113,7 @@ function _drawWall(p1, p2, minZ, maxZ, r, g, b, a)
   local topLeft = vector3(p1.x, p1.y, maxZ)
   local bottomRight = vector3(p2.x, p2.y, minZ)
   local topRight = vector3(p2.x, p2.y, maxZ)
-  
+
   DrawPoly(bottomLeft,topLeft,bottomRight,r,g,b,a)
   DrawPoly(topLeft,topRight,bottomRight,r,g,b,a)
   DrawPoly(bottomRight,topRight,topLeft,r,g,b,a)
@@ -135,7 +135,7 @@ function PolyZone:draw()
   local plyPos = GetEntityCoords(plyPed)
   local minZ = self.minZ or plyPos.z - zDrawDist
   local maxZ = self.maxZ or plyPos.z + zDrawDist
-  
+
   local points = self.points
   for i=1, #points do
     local point = self:TransformPoint(points[i])
@@ -286,7 +286,7 @@ function _isGridCellInsidePoly(cellX, cellY, poly)
       end
     end
   end
-  
+
   return true
 end
 
@@ -429,7 +429,7 @@ local function _initDebug(poly, options)
   if not debugEnabled then
     return
   end
-  
+
   Citizen.CreateThread(function()
     while not poly.destroyed do
       poly:draw()
@@ -490,7 +490,7 @@ end
 function PolyZone:isPointInside(point)
   if self.destroyed then
     print("[PolyZone] Warning: Called isPointInside on destroyed zone {name=" .. self.name .. "}")
-    return false 
+    return false
   end
 
   return _pointInPoly(point, self)

--- a/creation/client/BoxZone.lua
+++ b/creation/client/BoxZone.lua
@@ -2,36 +2,29 @@ local function handleInput(useZ, heading, length, width, center)
   if not useZ then
     local scaleDelta, headingDelta = 0.2, 5
     BlockWeaponWheelThisFrame()
-    DisableControlAction(0, 36, true)
-    DisableControlAction(0, 81, true)
-    DisableControlAction(0, 99, true)
 
     if IsDisabledControlPressed(0, 36) then -- ctrl held down
       scaleDelta, headingDelta = 0.05, 1
     end
 
     if IsDisabledControlJustPressed(0, 81) then -- scroll wheel down just pressed
-      EnableControlAction(0, 19, true)
-      EnableControlAction(0, 21, true)
 
-      if IsControlPressed(0, 19) then -- alt held down
+      if IsDisabledControlPressed(0, 19) then -- alt held down
         return heading, length, math.max(0.0, width - scaleDelta), center
       end
-      if IsControlPressed(0, 21) then -- shift held down
+      if IsDisabledControlPressed(0, 21) then -- shift held down
         return heading, math.max(0.0, length - scaleDelta), width, center
       end
       return (heading - headingDelta) % 360, length, width, center
     end
-    
+
 
     if IsDisabledControlJustPressed(0, 99) then -- scroll wheel up just pressed
-      EnableControlAction(0, 19, true)
-      EnableControlAction(0, 21, true)
 
-      if IsControlPressed(0, 19) then -- alt held down
+      if IsDisabledControlPressed(0, 19) then -- alt held down
         return heading, length, math.max(0.0, width + scaleDelta), center
       end
-      if IsControlPressed(0, 21) then -- shift held down
+      if IsDisabledControlPressed(0, 21) then -- shift held down
         return heading, math.max(0.0, length + scaleDelta), width, center
       end
       return (heading + headingDelta) % 360, length, width, center
@@ -46,9 +39,6 @@ end
 
 function handleZ(minZ, maxZ)
   local delta = 0.2
-  DisableControlAction(0, 36, true)
-  DisableControlAction(0, 99, true)
-  DisableControlAction(0, 81, true)
 
   if IsDisabledControlPressed(0, 36) then -- ctrl held down
     delta = 0.05
@@ -57,26 +47,22 @@ function handleZ(minZ, maxZ)
   BlockWeaponWheelThisFrame()
 
   if IsDisabledControlJustPressed(0, 81) then -- scroll wheel down just pressed
-    EnableControlAction(0, 19, true)
-    EnableControlAction(0, 21, true)
 
-    if IsControlPressed(0, 19) then -- alt held down
+    if IsDisabledControlPressed(0, 19) then -- alt held down
       return minZ - delta, maxZ
     end
-    if IsControlPressed(0, 21) then -- shift held down
+    if IsDisabledControlPressed(0, 21) then -- shift held down
       return minZ, maxZ - delta
     end
     return minZ - delta, maxZ - delta
   end
-  
-  if IsDisabledControlJustPressed(0, 99) then -- scroll wheel up just pressed
-    EnableControlAction(0, 19, true)
-    EnableControlAction(0, 21, true)
 
-    if IsControlPressed(0, 19) then -- alt held down
+  if IsDisabledControlJustPressed(0, 99) then -- scroll wheel up just pressed
+
+    if IsDisabledControlPressed(0, 19) then -- alt held down
       return minZ + delta, maxZ
     end
-    if IsControlPressed(0, 21) then -- shift held down
+    if IsDisabledControlPressed(0, 21) then -- shift held down
       return minZ, maxZ + delta
     end
     return minZ + delta, maxZ + delta
@@ -98,8 +84,7 @@ function boxStart(name, heading, length, width, minHeight, maxHeight)
   end
   Citizen.CreateThread(function()
     while createdZone do
-      EnableControlAction(0, 20, true)
-      if IsControlJustPressed(0, 20) then -- Z pressed
+      if IsDisabledControlJustPressed(0, 20) then -- Z pressed
         useZ = not useZ
         if useZ then
           createdZone.debugColors.walls = {255, 0, 0}

--- a/creation/client/BoxZone.lua
+++ b/creation/client/BoxZone.lua
@@ -3,27 +3,35 @@ local function handleInput(useZ, heading, length, width, center)
     local scaleDelta, headingDelta = 0.2, 5
     BlockWeaponWheelThisFrame()
     DisableControlAction(0, 36, true)
+    DisableControlAction(0, 81, true)
+    DisableControlAction(0, 99, true)
+
     if IsDisabledControlPressed(0, 36) then -- ctrl held down
       scaleDelta, headingDelta = 0.05, 1
     end
 
-    DisableControlAction(0, 81, true)
-    if IsControlKeyJustPressed(0, 81) then
-      if IsControlKeyJustPressed(0, 19) then -- alt held down
+    if IsDisabledControlJustPressed(0, 81) then -- scroll wheel down just pressed
+      EnableControlAction(0, 19, true)
+      EnableControlAction(0, 21, true)
+
+      if IsControlPressed(0, 19) then -- alt held down
         return heading, length, math.max(0.0, width - scaleDelta), center
       end
-      if IsControlKeyJustPressed(0, 21) then -- shift held down
+      if IsControlPressed(0, 21) then -- shift held down
         return heading, math.max(0.0, length - scaleDelta), width, center
       end
       return (heading - headingDelta) % 360, length, width, center
     end
     
-    DisableControlAction(0, 99, true)
-    if IsControlKeyJustPressed(0, 99) then
-      if IsControlKeyJustPressed(0, 19) then -- alt held down
+
+    if IsDisabledControlJustPressed(0, 99) then -- scroll wheel up just pressed
+      EnableControlAction(0, 19, true)
+      EnableControlAction(0, 21, true)
+
+      if IsControlPressed(0, 19) then -- alt held down
         return heading, length, math.max(0.0, width + scaleDelta), center
       end
-      if IsControlKeyJustPressed(0, 21) then -- shift held down
+      if IsControlPressed(0, 21) then -- shift held down
         return heading, math.max(0.0, length + scaleDelta), width, center
       end
       return (heading + headingDelta) % 360, length, width, center
@@ -39,28 +47,36 @@ end
 function handleZ(minZ, maxZ)
   local delta = 0.2
   DisableControlAction(0, 36, true)
+  DisableControlAction(0, 99, true)
+  DisableControlAction(0, 81, true)
+
   if IsDisabledControlPressed(0, 36) then -- ctrl held down
     delta = 0.05
   end
 
   BlockWeaponWheelThisFrame()
-  DisableControlAction(0, 81, true)
-  if IsControlKeyJustPressed(0, 81) then
-    if IsControlKeyJustPressed(0, 19) then -- alt held down
+
+  if IsDisabledControlJustPressed(0, 81) then -- scroll wheel down just pressed
+    EnableControlAction(0, 19, true)
+    EnableControlAction(0, 21, true)
+
+    if IsControlPressed(0, 19) then -- alt held down
       return minZ - delta, maxZ
     end
-    if IsControlKeyJustPressed(0, 21) then -- shift held down
+    if IsControlPressed(0, 21) then -- shift held down
       return minZ, maxZ - delta
     end
     return minZ - delta, maxZ - delta
   end
   
-  DisableControlAction(0, 99, true)
-  if IsControlKeyJustPressed(0, 99) then
-    if IsControlKeyJustPressed(0, 19) then -- alt held down
+  if IsDisabledControlJustPressed(0, 99) then -- scroll wheel up just pressed
+    EnableControlAction(0, 19, true)
+    EnableControlAction(0, 21, true)
+
+    if IsControlPressed(0, 19) then -- alt held down
       return minZ + delta, maxZ
     end
-    if IsControlKeyJustPressed(0, 21) then -- shift held down
+    if IsControlPressed(0, 21) then -- shift held down
       return minZ, maxZ + delta
     end
     return minZ + delta, maxZ + delta
@@ -82,6 +98,7 @@ function boxStart(name, heading, length, width, minHeight, maxHeight)
   end
   Citizen.CreateThread(function()
     while createdZone do
+      EnableControlAction(0, 20, true)
       if IsControlJustPressed(0, 20) then -- Z pressed
         useZ = not useZ
         if useZ then

--- a/creation/client/BoxZone.lua
+++ b/creation/client/BoxZone.lua
@@ -8,22 +8,22 @@ local function handleInput(useZ, heading, length, width, center)
     end
 
     DisableControlAction(0, 81, true)
-    if IsDisabledControlJustPressed(0, 81) then
-      if IsControlPressed(0, 19) then -- alt held down
+    if IsControlKeyJustPressed(0, 81) then
+      if IsControlKeyJustPressed(0, 19) then -- alt held down
         return heading, length, math.max(0.0, width - scaleDelta), center
       end
-      if IsControlPressed(0, 21) then -- shift held down
+      if IsControlKeyJustPressed(0, 21) then -- shift held down
         return heading, math.max(0.0, length - scaleDelta), width, center
       end
       return (heading - headingDelta) % 360, length, width, center
     end
     
     DisableControlAction(0, 99, true)
-    if IsDisabledControlJustPressed(0, 99) then
-      if IsControlPressed(0, 19) then -- alt held down
+    if IsControlKeyJustPressed(0, 99) then
+      if IsControlKeyJustPressed(0, 19) then -- alt held down
         return heading, length, math.max(0.0, width + scaleDelta), center
       end
-      if IsControlPressed(0, 21) then -- shift held down
+      if IsControlKeyJustPressed(0, 21) then -- shift held down
         return heading, math.max(0.0, length + scaleDelta), width, center
       end
       return (heading + headingDelta) % 360, length, width, center
@@ -45,22 +45,22 @@ function handleZ(minZ, maxZ)
 
   BlockWeaponWheelThisFrame()
   DisableControlAction(0, 81, true)
-  if IsDisabledControlJustPressed(0, 81) then
-    if IsControlPressed(0, 19) then -- alt held down
+  if IsControlKeyJustPressed(0, 81) then
+    if IsControlKeyJustPressed(0, 19) then -- alt held down
       return minZ - delta, maxZ
     end
-    if IsControlPressed(0, 21) then -- shift held down
+    if IsControlKeyJustPressed(0, 21) then -- shift held down
       return minZ, maxZ - delta
     end
     return minZ - delta, maxZ - delta
   end
   
   DisableControlAction(0, 99, true)
-  if IsDisabledControlJustPressed(0, 99) then
-    if IsControlPressed(0, 19) then -- alt held down
+  if IsControlKeyJustPressed(0, 99) then
+    if IsControlKeyJustPressed(0, 19) then -- alt held down
       return minZ + delta, maxZ
     end
-    if IsControlPressed(0, 21) then -- shift held down
+    if IsControlKeyJustPressed(0, 21) then -- shift held down
       return minZ, maxZ + delta
     end
     return minZ + delta, maxZ + delta

--- a/creation/client/CircleZone.lua
+++ b/creation/client/CircleZone.lua
@@ -1,25 +1,31 @@
 local function handleInput(radius, center, useZ)
   local delta = 0.05
   BlockWeaponWheelThisFrame()
+
   DisableControlAction(0, 36, true)
-  DisableControlAction(0, 81, true)
   if IsDisabledControlPressed(0, 36) then -- ctrl held down
     delta = 0.01
   end
-  if IsControlKeyJustPressed(0, 81) then
-    if IsControlKeyJustPressed(0, 19) then -- alt held down
+
+  DisableControlAction(0, 81, true)
+  if IsDisabledControlJustPressed(0, 81) then -- scroll wheel down just pressed
+    EnableControlAction(0, 19, true)
+    if IsControlPressed(0, 19) then -- alt held down
       return radius, vector3(center.x, center.y, center.z - delta), useZ
     end
     return math.max(0.0, radius - delta), center, useZ
   end
+
   DisableControlAction(0, 99, true)
-  if IsControlKeyJustPressed(0, 99) then
-    if IsControlKeyJustPressed(0, 19) then -- alt held down
+  if IsDisabledControlJustPressed(0, 99) then -- scroll wheel up just pressed
+    EnableControlAction(0, 19, true)
+    if IsControlPressed(0, 19) then -- alt held down
       return radius, vector3(center.x, center.y, center.z + delta), useZ
     end
     return radius + delta, center, useZ
   end
 
+  EnableControlAction(0, 20, true)
   if IsControlJustPressed(0, 20) then -- Z pressed
     return radius, center, not useZ
   end

--- a/creation/client/CircleZone.lua
+++ b/creation/client/CircleZone.lua
@@ -2,31 +2,28 @@ local function handleInput(radius, center, useZ)
   local delta = 0.05
   BlockWeaponWheelThisFrame()
 
-  DisableControlAction(0, 36, true)
   if IsDisabledControlPressed(0, 36) then -- ctrl held down
     delta = 0.01
   end
 
-  DisableControlAction(0, 81, true)
   if IsDisabledControlJustPressed(0, 81) then -- scroll wheel down just pressed
-    EnableControlAction(0, 19, true)
-    if IsControlPressed(0, 19) then -- alt held down
+
+    if IsDisabledControlPressed(0, 19) then -- alt held down
       return radius, vector3(center.x, center.y, center.z - delta), useZ
     end
     return math.max(0.0, radius - delta), center, useZ
   end
 
-  DisableControlAction(0, 99, true)
+
   if IsDisabledControlJustPressed(0, 99) then -- scroll wheel up just pressed
-    EnableControlAction(0, 19, true)
-    if IsControlPressed(0, 19) then -- alt held down
+
+    if IsDisabledControlPressed(0, 19) then -- alt held down
       return radius, vector3(center.x, center.y, center.z + delta), useZ
     end
     return radius + delta, center, useZ
   end
 
-  EnableControlAction(0, 20, true)
-  if IsControlJustPressed(0, 20) then -- Z pressed
+  if IsDisabledControlJustPressed(0, 20) then -- Z pressed
     return radius, center, not useZ
   end
 

--- a/creation/client/CircleZone.lua
+++ b/creation/client/CircleZone.lua
@@ -6,15 +6,15 @@ local function handleInput(radius, center, useZ)
   if IsDisabledControlPressed(0, 36) then -- ctrl held down
     delta = 0.01
   end
-  if IsDisabledControlJustPressed(0, 81) then
-    if IsControlPressed(0, 19) then -- alt held down
+  if IsControlKeyJustPressed(0, 81) then
+    if IsControlKeyJustPressed(0, 19) then -- alt held down
       return radius, vector3(center.x, center.y, center.z - delta), useZ
     end
     return math.max(0.0, radius - delta), center, useZ
   end
   DisableControlAction(0, 99, true)
-  if IsDisabledControlJustPressed(0, 99) then
-    if IsControlPressed(0, 19) then -- alt held down
+  if IsControlKeyJustPressed(0, 99) then
+    if IsControlKeyJustPressed(0, 19) then -- alt held down
       return radius, vector3(center.x, center.y, center.z + delta), useZ
     end
     return radius + delta, center, useZ

--- a/creation/client/creation.lua
+++ b/creation/client/creation.lua
@@ -59,6 +59,7 @@ AddEventHandler("polyzone:pzcreate", function(zoneType, name, args)
   end
   createdZoneType = zoneType
   drawZone = true
+  disableControlKeyInput()
   drawThread()
 end)
 
@@ -101,7 +102,6 @@ AddEventHandler("polyzone:pzlast", function()
       multiline = true,
       args = {"Me", "The command pzlast only supports BoxZone and CircleZone for now"}
     })
-  
   end
 
   local name = GetUserInput("Enter name (or leave empty to reuse last zone's name):")
@@ -124,6 +124,7 @@ AddEventHandler("polyzone:pzlast", function()
     circleStart(name, lastCreatedZone.radius, lastCreatedZone.useZ)
   end
   drawZone = true
+  disableControlKeyInput()
   drawThread()
 end)
 

--- a/creation/client/utils.lua
+++ b/creation/client/utils.lua
@@ -29,31 +29,33 @@ end
 function handleArrowInput(center, heading)
   delta = 0.05
   DisableControlAction(0, 36, true)
-  if IsControlKeyJustPressed(0, 36) then -- ctrl held down
+  if IsDisabledControlPressed(0, 36) then -- ctrl held down
     delta = 0.01
   end
 
-  DisableControlAction(0, 27, true)
-  if IsControlKeyJustPressed(0, 27) then -- arrow up
+  EnableControlAction(0, 172, true)
+  if IsControlPressed(0, 172) then -- arrow up
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x, center.y + delta), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
-  if IsControlKeyJustPressed(0, 173) then -- arrow down
+
+  EnableControlAction(0, 173, true)
+  if IsControlPressed(0, 173) then -- arrow down
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x, center.y - delta), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
-  if IsControlKeyJustPressed(0, 174) then -- arrow left
+
+  EnableControlAction(0, 174, true)
+  if IsControlPressed(0, 174) then -- arrow left
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x - delta, center.y), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
-  if IsControlKeyJustPressed(0, 175) then -- arrow right
+
+  EnableControlAction(0, 175, true)
+  if IsControlPressed(0, 175) then -- arrow right
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x + delta, center.y), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
 
   return center
-end
-
-IsControlKeyJustPressed = function(inputGroup, control)
-  return IsControlPressed(inputGroup, control) or IsDisabledControlPressed(inputGroup, control)
 end

--- a/creation/client/utils.lua
+++ b/creation/client/utils.lua
@@ -57,21 +57,19 @@ function handleArrowInput(center, heading)
 end
 
 function disableControlKeyInput()
-  if not drawZone then
-    Citizen.CreateThread(function()
-      while drawZone do
-        DisableControlAction(0, 36, true)   -- Ctrl
-        DisableControlAction(0, 19, true)   -- Alt
-        DisableControlAction(0, 20, true)   -- 'Z'
-        DisableControlAction(0, 21, true)   -- Shift
-        DisableControlAction(0, 81, true)   -- Scroll Wheel Down
-        DisableControlAction(0, 99, true)   -- Scroll Wheel Up
-        DisableControlAction(0, 172, true)  -- Arrow Up
-        DisableControlAction(0, 173, true)  -- Arrow Down
-        DisableControlAction(0, 174, true)  -- Arrow Left
-        DisableControlAction(0, 175, true)  -- Arrow Right
-        Wait(0)
-      end
-    end)
-  end
+  Citizen.CreateThread(function()
+    while drawZone do
+      DisableControlAction(0, 36, true)   -- Ctrl
+      DisableControlAction(0, 19, true)   -- Alt
+      DisableControlAction(0, 20, true)   -- 'Z'
+      DisableControlAction(0, 21, true)   -- Shift
+      DisableControlAction(0, 81, true)   -- Scroll Wheel Down
+      DisableControlAction(0, 99, true)   -- Scroll Wheel Up
+      DisableControlAction(0, 172, true)  -- Arrow Up
+      DisableControlAction(0, 173, true)  -- Arrow Down
+      DisableControlAction(0, 174, true)  -- Arrow Left
+      DisableControlAction(0, 175, true)  -- Arrow Right
+      Wait(0)
+    end
+  end)
 end

--- a/creation/client/utils.lua
+++ b/creation/client/utils.lua
@@ -28,34 +28,50 @@ end
 
 function handleArrowInput(center, heading)
   delta = 0.05
-  DisableControlAction(0, 36, true)
+
   if IsDisabledControlPressed(0, 36) then -- ctrl held down
     delta = 0.01
   end
 
-  EnableControlAction(0, 172, true)
-  if IsControlPressed(0, 172) then -- arrow up
+  if IsDisabledControlPressed(0, 172) then -- arrow up
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x, center.y + delta), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
 
-  EnableControlAction(0, 173, true)
-  if IsControlPressed(0, 173) then -- arrow down
+  if IsDisabledControlPressed(0, 173) then -- arrow down
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x, center.y - delta), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
 
-  EnableControlAction(0, 174, true)
-  if IsControlPressed(0, 174) then -- arrow left
+  if IsDisabledControlPressed(0, 174) then -- arrow left
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x - delta, center.y), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
 
-  EnableControlAction(0, 175, true)
-  if IsControlPressed(0, 175) then -- arrow right
+  if IsDisabledControlPressed(0, 175) then -- arrow right
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x + delta, center.y), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
 
   return center
+end
+
+function disableControlKeyInput()
+  if not drawZone then
+    Citizen.CreateThread(function()
+      while drawZone do
+        DisableControlAction(0, 36, true)   -- Ctrl
+        DisableControlAction(0, 19, true)   -- Alt
+        DisableControlAction(0, 20, true)   -- 'Z'
+        DisableControlAction(0, 21, true)   -- Shift
+        DisableControlAction(0, 81, true)   -- Scroll Wheel Down
+        DisableControlAction(0, 99, true)   -- Scroll Wheel Up
+        DisableControlAction(0, 172, true)  -- Arrow Up
+        DisableControlAction(0, 173, true)  -- Arrow Down
+        DisableControlAction(0, 174, true)  -- Arrow Left
+        DisableControlAction(0, 175, true)  -- Arrow Right
+        Wait(0)
+      end
+    end)
+  end
 end

--- a/creation/client/utils.lua
+++ b/creation/client/utils.lua
@@ -29,27 +29,31 @@ end
 function handleArrowInput(center, heading)
   delta = 0.05
   DisableControlAction(0, 36, true)
-  if IsDisabledControlPressed(0, 36) then -- ctrl held down
+  if IsControlKeyJustPressed(0, 36) then -- ctrl held down
     delta = 0.01
   end
 
   DisableControlAction(0, 27, true)
-  if IsDisabledControlPressed(0, 27) then -- arrow up
+  if IsControlKeyJustPressed(0, 27) then -- arrow up
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x, center.y + delta), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
-  if IsControlPressed(0, 173) then -- arrow down
+  if IsControlKeyJustPressed(0, 173) then -- arrow down
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x, center.y - delta), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
-  if IsControlPressed(0, 174) then -- arrow left
+  if IsControlKeyJustPressed(0, 174) then -- arrow left
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x - delta, center.y), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
-  if IsControlPressed(0, 175) then -- arrow right
+  if IsControlKeyJustPressed(0, 175) then -- arrow right
     local newCenter =  PolyZone.rotate(center.xy, vector2(center.x + delta, center.y), heading)
     return vector3(newCenter.x, newCenter.y, center.z)
   end
 
   return center
+end
+
+IsControlKeyJustPressed = function(inputGroup, control)
+  return IsControlPressed(inputGroup, control) or IsDisabledControlPressed(inputGroup, control)
 end


### PR DESCRIPTION
Enables key binds for poly manipulation regardless if a key is enabled or disabled.

A lot of no-clips disable input of all types, making the IsControlJustPressed not trigger. Essentially just makes this script compatible with a lot of other scripts that disable input of certain types.