### PR TITLE
feat: Allow to change wall/grid/outline colors if zone is already created

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -597,3 +597,27 @@ end
 function PolyZone:getBoundingBoxCenter()
   return self.center
 end
+
+function PolyZone:SetWallColor(r,g,b)
+  if type(r) ~= "number" or type(g) ~= "number" or type(b) ~= "number" then
+    return
+  end
+  
+  self.debugColors.walls = {r,g,b}
+end
+
+function PolyZone:SetGridColor(r,g,b)
+  if type(r) ~= "number" or type(g) ~= "number" or type(b) ~= "number" then
+    return
+  end
+
+  self.debugColors.grid = {r,g,b}
+end
+
+function PolyZone:SetOutlineColor(r,g,b)
+  if type(r) ~= "number" or type(g) ~= "number" or type(b) ~= "number" then
+    return
+  end
+  
+  self.debugColors.outline = {r,g,b}
+end


### PR DESCRIPTION
This change simply adds 3 new functions `PolyZone:SetWallColor`, `PolyZone:SetGridColor`and `PolyZone:SetOutlineColor`.

This would be useful if someone would like to have different debug colors on the fly.
Currently I'm using this myself to debug some zones.

For example: 
 1. Zone turns yellow if a object is not spawned and waiting for cooldown
 2. Zone is green when everything is spawned and ready for user action
 3. Zone is read when player is in the zone

Example video https://www.youtube.com/embed/SN8Hqjt1TLc

<video width="320" height="240" controls>
  <source src="[video.mov](https://www.youtube.com/watch?v=SN8Hqjt1TLc)" type="video/mp4">
</video>

These are just a few examples I've been able to achieve adding this functionality