### PR TITLE
fix(creation): don't use UTC time

### DIFF
--- a/creation/server/creation.lua
+++ b/creation/server/creation.lua
@@ -25,7 +25,7 @@ function round(num, numDecimalPlaces)
 end
 
 function printoutHeader(name)
-  return "-- Name: " .. name .. " | " .. os.date("!%Y-%m-%dT%H:%M:%SZ\n")
+  return "-- Name: " .. name .. " | " .. os.date("%Y-%m-%dT%H:%M:%SZ\n")
 end
 
 function parsePoly(zone)


### PR DESCRIPTION
Since https://github.com/citizenfx/fivem/commit/b446b22945e3121f41738597ecaf288711975f8d, UTC time formatting appears to be broken, causing null to be inserted after the formatted time.

This seems to affect content length calculation, as another proposed fix https://github.com/mkafrin/PolyZone/issues/117 by @DB00001010 only updates dataLength in **SaveResourceFile** from -1 to the actual length.