### PR TITLE
fix: fix output error after using "pzfinish" command

### DIFF
--- a/creation/server/creation.lua
+++ b/creation/server/creation.lua
@@ -25,7 +25,9 @@ function round(num, numDecimalPlaces)
 end
 
 function printoutHeader(name)
-  return "-- Name: " .. name .. " | " .. os.date("!%Y-%m-%dT%H:%M:%SZ\n")
+  local header = "-- Name: " .. name .. " | " .. os.date("!%Y-%m-%dT%H:%M:%SZ\n")
+  header = string.gsub(header, "\0", "")
+  return header
 end
 
 function parsePoly(zone)


### PR DESCRIPTION
In lua, if you use os.date(), it would generate "\0" in the end of the output strings.
It makes fivem can not output correct strings in .txt file, so we need to clean "\0" chars in the strings.
![image](https://github.com/user-attachments/assets/00f60a86-56f1-41a7-8282-72d040213225)